### PR TITLE
feat: Simple installation script for MSSQL tools (Issue #14)

### DIFF
--- a/MSSQL_TOOLS_SETUP.md
+++ b/MSSQL_TOOLS_SETUP.md
@@ -1,0 +1,74 @@
+# Microsoft SQL Server Tools Setup
+
+This document explains how to install Microsoft SQL Server command line tools (sqlcmd and bcp) in the Babelfish DevContainer.
+
+## Quick Installation
+
+After your DevContainer is running, execute this command inside the container:
+
+```bash
+# From inside the container (as root)
+bash /workspace/install_mssql_tools.sh
+```
+
+Or from the host machine:
+
+```bash
+# From host machine
+docker exec -it docker-babelfishpg-devtools_devcontainer-babelfish-1 bash /workspace/install_mssql_tools.sh
+```
+
+## Testing the Installation
+
+After installation, test sqlcmd:
+
+```bash
+# From inside container
+sqlcmd -S localhost,1433 -U floorzapadmin -P secret_password -C -Q "SELECT @@version"
+
+# From host machine
+sqlcmd -S localhost,3341 -U floorzapadmin -P secret_password -C -Q "SELECT @@version"
+```
+
+**Note:** The `-C` flag is required to trust the self-signed SSL certificate.
+
+## Expected Output
+
+```sql
+Babelfish for PostgreSQL with SQL Server Compatibility - 12.0.2000.8
+Sep 10 2025 18:14:00
+Copyright (c) Amazon Web Services
+PostgreSQL 17.5 on x86_64-pc-linux-gnu (Babelfish 5.2.0)
+```
+
+## What Gets Installed
+
+- **msodbcsql18** - Microsoft ODBC Driver 18 for SQL Server
+- **mssql-tools18** - Command line tools including:
+  - `sqlcmd` - SQL Server command line query tool
+  - `bcp` - Bulk copy program
+
+## Installation Details
+
+The script:
+1. Adds Microsoft's APT repository
+2. Installs the ODBC driver and tools
+3. Configures PATH environment
+4. Creates symbolic links in `/usr/local/bin` for immediate access
+
+## Troubleshooting
+
+If sqlcmd is not found after installation:
+1. Source the profile: `source /etc/profile.d/mssql.sh`
+2. Or manually add to PATH: `export PATH="$PATH:/opt/mssql-tools18/bin"`
+
+## Port Mappings
+
+| Location | Port | Description |
+|----------|------|-------------|
+| Inside container | 1433 | Babelfish TDS endpoint |
+| From host | 3341 | Mapped container port 1433 |
+
+## Related Issue
+
+This installation script addresses Issue #14 - Add Microsoft SQL Server command line tools.

--- a/install_mssql_tools.sh
+++ b/install_mssql_tools.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Install Microsoft SQL Server command line tools
+# This script can be run inside the container to add sqlcmd and bcp utilities
+
+set -e
+
+echo "Installing Microsoft SQL Server command line tools..."
+
+# Add Microsoft GPG key
+curl -s https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+
+# Add Microsoft SQL Server Ubuntu repository
+curl -s https://packages.microsoft.com/config/ubuntu/22.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+
+# Update package list
+apt-get update
+
+# Install MSSQL tools with automatic EULA acceptance
+ACCEPT_EULA=Y apt-get install -y --no-install-recommends \
+    msodbcsql18 \
+    mssql-tools18
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+# Add tools to PATH
+echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> /etc/profile.d/mssql.sh
+echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> /etc/bash.bashrc
+
+# Create symbolic links for immediate access
+ln -sf /opt/mssql-tools18/bin/sqlcmd /usr/local/bin/sqlcmd
+ln -sf /opt/mssql-tools18/bin/bcp /usr/local/bin/bcp
+
+echo "MSSQL tools installation complete!"
+echo ""
+echo "Usage:"
+echo "  sqlcmd -S localhost,1433 -U floorzapadmin -P secret_password -C -Q \"SELECT @@version\""
+echo ""
+echo "Note: The -C flag is required to trust the self-signed certificate"


### PR DESCRIPTION
## Summary
Provides a simple, reliable way to install Microsoft SQL Server command line tools without modifying the Dockerfile or DevContainer configuration.

## Approach
After encountering build issues with DevContainer features overriding the Dockerfile (see PR #18), this PR takes a simpler approach:
- Provide an installation script that can be run **after** the container is running
- Avoids complex Dockerfile modifications that conflict with DevContainer
- Tools are installed on-demand when needed

## Files Added
- `install_mssql_tools.sh` - Bash script to install sqlcmd and bcp
- `MSSQL_TOOLS_SETUP.md` - Documentation for installation and usage

## Installation Process
1. Start your DevContainer normally
2. Run the installation script:
   ```bash
   bash /workspace/install_mssql_tools.sh
   ```
3. Test with:
   ```bash
   sqlcmd -S localhost,1433 -U floorzapadmin -P secret_password -C -Q "SELECT @@version"
   ```

## Benefits
✅ No Dockerfile changes needed
✅ No DevContainer configuration changes
✅ Works with existing setup
✅ Can be run on any running container
✅ Clear, simple installation process

## Testing
The script has been tested by:
1. Running on a fresh container
2. Verifying sqlcmd connects to Babelfish
3. Confirming the expected version output

## Related Issue
Closes #14

## Previous Attempt
PR #18 attempted to add MSSQL tools directly to the Dockerfile but encountered issues with DevContainer features creating temporary Dockerfiles that overrode our changes. This simpler approach avoids those problems entirely.